### PR TITLE
Import samba-4.23.3-2.xs8

### DIFF
--- a/SOURCES/smb.conf.extra
+++ b/SOURCES/smb.conf.extra
@@ -1,0 +1,10 @@
+# See smb.conf.example for a more detailed config file or
+# read the smb.conf manpage.
+# Run 'testparm' to verify the config is correct after
+# you modified it.
+#
+# Note:
+# This file overrides /etc/samba/smb.conf which is controlled by xapi, use it carefully
+# This file will NOT be retained through system upgrades to newer releases.
+
+[global]

--- a/SPECS/samba.spec
+++ b/SPECS/samba.spec
@@ -1,6 +1,6 @@
-%global package_speccommit c513d7e011e2c06dc3b1b34191a2f33d3eecd708
+%global package_speccommit 39d3e5a4977562164c8b771f7be223a332f09a7e
 %global usver 4.23.3
-%global xsver 1
+%global xsver 2
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 %global package_srccommit samba-4.23.3
 
@@ -167,6 +167,7 @@ Source15: usershares.conf.vendor
 Source16: samba-systemd-sysusers.conf
 Source17: samba-usershares-systemd-sysusers.conf
 Source18: samba-winbind-systemd-sysusers.conf
+Source30: smb.conf.extra
 
 Source201: README.downgrade
 Source202: samba.abignore
@@ -1419,6 +1420,7 @@ install -d -m 0755 %{buildroot}%{_sysconfdir}/logrotate.d
 install -m 0644 %{SOURCE10} %{buildroot}%{_sysconfdir}/logrotate.d/samba
 
 install -m 0644 %{SOURCE11} %{buildroot}%{_sysconfdir}/samba/smb.conf
+install -m 0644 %{SOURCE30} %{buildroot}%{_sysconfdir}/samba/smb.extra.conf
 install -m 0644 %{SOURCE12} %{buildroot}%{_sysconfdir}/samba/smb.conf.example
 install -m 0644 %{SOURCE15} %{buildroot}%{_sysconfdir}/samba/usershares.conf
 
@@ -1905,6 +1907,7 @@ fi
 %dir /var/lib/samba/lock
 %attr(755,root,root) %dir %{_sysconfdir}/samba
 %config(noreplace) %{_sysconfdir}/samba/smb.conf
+%config(noreplace) %{_sysconfdir}/samba/smb.extra.conf
 %{_sysconfdir}/samba/smb.conf.example
 %config(noreplace) %{_sysconfdir}/samba/lmhosts
 %config(noreplace) %{_sysconfdir}/sysconfig/samba
@@ -3801,6 +3804,9 @@ fi
 
 
 %changelog
+* Fri Jan 30 2026 Lin Liu <lin.liu01@citrix.com> - 4.23.3-2
+- CP-311169: include /etc/samba/smb.extra.conf
+
 * Mon Nov 24 2025 Lin Liu <Lin.Liu01@cloud.com> - 4.23.3-1
 - CP-310101: Update samba to support ldaps and windows security hardening
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3082

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

- https://github.com/xcp-ng-rpms/samba/pull/7 (to be same milestone, see attention points)

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Config is managed by XAPI  (note that later change will remove servers since XCP-ng does not want this feature)

#### Release Target

- [x] I haven't talked with the release team, but I have a proposed target.

next+2


### Release Notes and Documentation

#### Explain the change to users

Samba configuration is not more configurable directly (It will be managed by xapi)

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

It can confuse users if we remove servers in next PR, this would break samba feature, I think i makes sense to group both changes in the same milestone.

#### Documentation update needed

- [ ] Yes
- [ ] No
- [x] I'm not sure, help me


EXPLANATIONS

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: LINKS, TODO, or N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

xcp-ng-tests's main on nested hosts

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

none atm, but a client mount would not hurt

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

TBC

#### What tests have been or will be added to CI for this change? If none, explain why.

TBC

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
